### PR TITLE
feat: add multiple feature flags with enhanced metadata capabilities for testing

### DIFF
--- a/bruno-athaide-product-test/poc-config-v2/prod.tf
+++ b/bruno-athaide-product-test/poc-config-v2/prod.tf
@@ -124,3 +124,150 @@ resource "configcat_setting_value_v2" "bool_setting_value" {
     },
   ]
 }
+
+# Create feature flag with extra metadata fields
+resource "configcat_setting" "metadata_test_flag" {
+  config_id    = configcat_config.my_config.id
+  key          = "metadataTestFlag"
+  name         = "Metadata Test Feature Flag"
+  hint         = "Testing extra metadata fields like expiry_date and active status"
+  order        = 3
+  setting_type = "boolean"
+}
+
+# Create setting value for metadata test flag
+resource "configcat_setting_value_v2" "metadata_test_flag_value" {
+  environment_id = data.configcat_environments.prod_environment.environments.0.environment_id
+  setting_id     = configcat_setting.metadata_test_flag.id
+
+  value = { bool_value = true }
+
+  # Test if we can add metadata to setting values as well
+  mandatory_notes = "Testing metadata capabilities - expiry: 2024-12-31, active: true"
+
+  targeting_rules = [
+    {
+      conditions = [
+        {
+          user_condition = {
+            comparison_attribute = "email"
+            comparator           = "sensitiveTextEquals"
+            comparison_value     = { string_value = "@configcat.com" }
+          }
+        }
+      ]
+      value = { bool_value = false }
+    }
+  ]
+}
+
+# Create another setting to test different metadata approaches
+resource "configcat_setting" "advanced_metadata_flag" {
+  config_id    = configcat_config.my_config.id
+  key          = "advancedMetadataFlag"
+  name         = "Advanced Metadata Feature Flag"
+  hint         = "Testing various metadata field approaches"
+  order        = 4
+  setting_type = "string"
+}
+
+# Create setting value with metadata in notes
+resource "configcat_setting_value_v2" "advanced_metadata_flag_value" {
+  environment_id = data.configcat_environments.prod_environment.environments.0.environment_id
+  setting_id     = configcat_setting.advanced_metadata_flag.id
+
+  value = { string_value = "default_value" }
+
+  # Store metadata as structured notes to see if we can work around provider limitations
+  mandatory_notes = "METADATA: {\"expiry_date\": \"2024-12-31\", \"active\": true, \"priority\": \"high\", \"owner\": \"qa-team\"}"
+
+  targeting_rules = [
+    {
+      conditions = [
+        {
+          user_condition = {
+            comparison_attribute = "email"
+            comparator           = "sensitiveTextEquals"
+            comparison_value     = { string_value = "@configcat.com" }
+          }
+        }
+      ]
+      value = { string_value = "internal_value" }
+    }
+  ]
+}
+
+# Create experimental metadata test setting
+resource "configcat_setting" "experimental_metadata_flag" {
+  config_id    = configcat_config.my_config.id
+  key          = "experimentalMetadataFlag"
+  name         = "Experimental Metadata Feature Flag"
+  hint         = "Testing experimental metadata fields to discover provider capabilities"
+  order        = 5
+  setting_type = "string"
+}
+
+# Create setting value with experimental metadata
+resource "configcat_setting_value_v2" "experimental_metadata_flag_value" {
+  environment_id = data.configcat_environments.prod_environment.environments.0.environment_id
+  setting_id     = configcat_setting.experimental_metadata_flag.id
+
+  value = { string_value = "experimental_value" }
+
+  # Test structured metadata in notes as a workaround
+  mandatory_notes = "EXPERIMENTAL_METADATA: {\"expiry_date\": \"2024-12-31\", \"active\": true, \"priority\": \"high\", \"owner\": \"qa-team\", \"created_by\": \"terraform\", \"environment\": \"production\", \"version\": \"1.0.0\"}"
+
+  targeting_rules = [
+    {
+      conditions = [
+        {
+          user_condition = {
+            comparison_attribute = "email"
+            comparator           = "sensitiveTextEquals"
+            comparison_value     = { string_value = "@configcat.com" }
+          }
+        }
+      ]
+      value = { string_value = "experimental_internal_value" }
+    }
+  ]
+}
+
+# Create a setting specifically for testing expiry and active metadata
+resource "configcat_setting" "expiry_active_test_flag" {
+  config_id    = configcat_config.my_config.id
+  key          = "expiryActiveTestFlag"
+  name         = "Expiry and Active Test Feature Flag"
+  hint         = "Testing expiry_date and active properties specifically"
+  order        = 6
+  setting_type = "boolean"
+
+  # The hint field can store metadata-like information
+  # hint = "EXPIRY: 2024-12-31, ACTIVE: true, PRIORITY: high"
+}
+
+# Create setting value with expiry and active metadata in notes
+resource "configcat_setting_value_v2" "expiry_active_test_flag_value" {
+  environment_id = data.configcat_environments.prod_environment.environments.0.environment_id
+  setting_id     = configcat_setting.expiry_active_test_flag.id
+
+  value = { bool_value = true }
+
+  # Store expiry and active metadata in mandatory notes
+  mandatory_notes = "EXPIRY_DATE: 2024-12-31T23:59:59Z, ACTIVE: true, PRIORITY: high, OWNER: qa-team, CREATED: 2024-01-01, EXPIRES: 2024-12-31"
+
+  targeting_rules = [
+    {
+      conditions = [
+        {
+          user_condition = {
+            comparison_attribute = "email"
+            comparator           = "sensitiveTextEquals"
+            comparison_value     = { string_value = "@configcat.com" }
+          }
+        }
+      ]
+      value = { bool_value = false }
+    }
+  ]
+}


### PR DESCRIPTION
# ConfigCat Terraform Provider Metadata Testing

## Overview

This document summarizes our testing of ConfigCat's metadata capabilities through the Terraform provider, specifically focusing on adding extra metadata fields like `expiry_date` and `active` properties to feature flag resources.

## What We Tested

### 1. **Supported Metadata Fields**

✅ **Working Fields:**

- `hint` - Can store descriptive metadata about the feature flag
- `mandatory_notes` - Can store structured metadata in setting values
- `name` - Human-readable name for the feature flag
- `description` - Detailed description (in config resources)

### 2. **Unsupported Metadata Fields**

❌ **Fields That Don't Work:**

- `tags` - Not supported by the provider
- `expiry_date` - No native support
- `active` - No native support
- `metadata` - No native support
- `custom_attributes` - No native support
- `extended_properties` - No native support
- `labels` - No native support
- `additional_fields` - No native support

## Metadata Workarounds

### **Option 1: Using `hint` Field**

```hcl
resource "configcat_setting" "metadata_test_flag" {
  # ... other fields ...
  hint = "EXPIRY: 2024-12-31, ACTIVE: true, PRIORITY: high"
}
```

### **Option 2: Using `mandatory_notes` in Setting Values**

```hcl
resource "configcat_setting_value_v2" "metadata_test_flag_value" {
  # ... other fields ...
  mandatory_notes = "EXPIRY_DATE: 2024-12-31T23:59:59Z, ACTIVE: true, PRIORITY: high, OWNER: qa-team"
}
```

### **Option 3: Structured JSON in Notes**

```hcl
resource "configcat_setting_value_v2" "advanced_metadata_flag_value" {
  # ... other fields ...
  mandatory_notes = "METADATA: {\"expiry_date\": \"2024-12-31\", \"active\": true, \"priority\": \"high\", \"owner\": \"qa-team\"}"
}
```

## Test Resources Created

### **Basic Metadata Test**

- **Resource**: `metadata_test_flag`
- **Type**: Boolean
- **Metadata**: Stored in `hint` and `mandatory_notes`

### **Advanced Metadata Test**

- **Resource**: `advanced_metadata_flag`
- **Type**: String
- **Metadata**: JSON-structured metadata in `mandatory_notes`

### **Experimental Metadata Test**

- **Resource**: `experimental_metadata_flag`
- **Type**: String
- **Metadata**: Comprehensive metadata with multiple fields

### **Expiry and Active Test**

- **Resource**: `expiry_active_test_flag`
- **Type**: Boolean
- **Metadata**: Specific focus on expiry_date and active properties

## Key Findings

### **1. Provider Limitations**

- The ConfigCat Terraform provider has **limited native metadata support**
- **No custom fields** beyond the standard ones
- **No tags system** like other cloud providers

### **2. Workable Solutions**

- **`hint` field** can store simple metadata
- **`mandatory_notes`** can store complex, structured metadata
- **JSON in notes** provides a flexible metadata storage solution

### **3. Best Practices**

- Use **structured JSON** in `mandatory_notes` for complex metadata
- Use **`hint`** for simple, human-readable metadata
- **Standardize metadata format** across your organization

## Example Metadata Schema

```json
{
  "expiry_date": "2024-12-31T23:59:59Z",
  "active": true,
  "priority": "high",
  "owner": "qa-team",
  "created_by": "terraform",
  "environment": "production",
  "version": "1.0.0",
  "tags": ["feature-flag", "metadata-test"],
  "documentation": "https://docs.example.com/feature-flag-123"
}
```

## Recommendations

### **For Simple Metadata:**

```hcl
hint = "EXPIRY: 2024-12-31, ACTIVE: true"
```

### **For Complex Metadata:**

```hcl
mandatory_notes = "METADATA: {\"expiry_date\": \"2024-12-31\", \"active\": true, \"priority\": \"high\"}"
```

### **For Organization-Wide Standards:**

Create a metadata schema and use consistent formatting across all feature flags.

## Conclusion

While ConfigCat's Terraform provider doesn't support native custom metadata fields like `expiry_date` and `active`, we can effectively store this information using:

1. **`hint` field** for simple metadata
2. **`mandatory_notes`** for complex, structured metadata
3. **JSON formatting** for machine-readable metadata

This approach provides flexibility and maintains the metadata within the ConfigCat system, even though it's not stored in dedicated fields.
